### PR TITLE
Fix DEPRECATION: Using the injected `container` is deprecated. #857

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -6,7 +6,6 @@ const { RSVP, on } = Ember;
 export default Ember.ObjectProxy.extend(Ember.Evented, {
   authenticator:       null,
   store:               null,
-  container:           null,
   isAuthenticated:     false,
   attemptedTransition: null,
   content:             { authenticated: {} },


### PR DESCRIPTION
Ember would try to validate each key of internal-session error
and rise a error in https://github.com/emberjs/ember.js/blob/v2.3.0/packages/ember-runtime/lib/inject.js#L55
i did not run the tests
